### PR TITLE
support transformers in response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ await createMapping({
 });
 ```
 
+To use this feature, make sure to start the wiremock docker with the `--local-response-templating` option.
 For more on templates see [wiremock docs](http://wiremock.org/docs/response-templating/)
 
 ###### base64Body?

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Type: `Record<string, any>`
 
 Type: `string`
 
+Body can be a template used to generate random responses, for example:
+
+```ts
+await createMapping({
+  request: { urlPathPattern: '/someUrl', method: HttpMethod.Post },
+  response: { status: 200, body: "{{randomValue length=33 type='ALPHANUMERIC'}}", transformers: ['response-template'] },
+});
+```
+
+For more on templates see [wiremock docs](http://wiremock.org/docs/response-templating/)
+
 ###### base64Body?
 
 Type: `string`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osskit/wiremock-client",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/osskit/wiremock-client.git"

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ interface SuccessResponse {
   status: number;
   jsonBody?: Record<string, any>;
   headers?: Record<string, any>;
+  transformers?: string[];
   body?: string;
   base64Body?: string;
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,14 +1,13 @@
 version: '3.9'
 
 services:
-    mocks:
-        image: wiremock/wiremock
-        ports:
-            - 8080:8080
-        command: '--verbose'
-    mocks2:
-        image: wiremock/wiremock
-        ports:
-            - 9090:8080
-        command: '--verbose'
-
+  mocks:
+    image: wiremock/wiremock
+    ports:
+      - 8080:8080
+    command: '--verbose --local-response-templating'
+  mocks2:
+    image: wiremock/wiremock
+    ports:
+      - 9090:8080
+    command: '--verbose --local-response-templating'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,9 +5,14 @@ services:
     image: wiremock/wiremock
     ports:
       - 8080:8080
-    command: '--verbose --local-response-templating'
+    command: '--verbose'
   mocks2:
     image: wiremock/wiremock
     ports:
       - 9090:8080
+    command: '--verbose'
+  mocks3:
+    image: wiremock/wiremock
+    ports:
+      - 7070:8080
     command: '--verbose --local-response-templating'

--- a/tests/specs/main.spec.ts
+++ b/tests/specs/main.spec.ts
@@ -164,12 +164,13 @@ describe('tests', () => {
     });
 
     it('returns mocked random transformed response', async () => {
+      setGlobalConfiguration({ baseUrl: 'http://localhost:7070' });
       await createMapping({
         request: { urlPathPattern: '/someUrl', method: HttpMethod.Post },
-        response: { status: 200, body: '{{randomValue length=33 type=\'ALPHANUMERIC\'}}', transformers: ['response-template'] },
+        response: { status: 200, body: "{{randomValue length=33 type='ALPHANUMERIC'}}", transformers: ['response-template'] },
       });
 
-      const response = await fetch('http://localhost:8080/someUrl', {
+      const response = await fetch('http://localhost:7070/someUrl', {
         method: HttpMethod.Post,
         body: JSON.stringify(body),
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/tests/specs/main.spec.ts
+++ b/tests/specs/main.spec.ts
@@ -163,6 +163,22 @@ describe('tests', () => {
       await expect(response.text()).resolves.toMatchSnapshot();
     });
 
+    it('returns mocked random transformed response', async () => {
+      await createMapping({
+        request: { urlPathPattern: '/someUrl', method: HttpMethod.Post },
+        response: { status: 200, body: '{{randomValue length=33 type=\'ALPHANUMERIC\'}}', transformers: ['response-template'] },
+      });
+
+      const response = await fetch('http://localhost:8080/someUrl', {
+        method: HttpMethod.Post,
+        body: JSON.stringify(body),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      await expect(response.text()).resolves.toHaveLength(33);
+    });
+
     it('returns mocked responses for prioritized request pattern', async () => {
       await createMapping({
         request: { urlPathPattern: '/someUrl', method: HttpMethod.Post },


### PR DESCRIPTION
allow dynamic response body with response templating
https://docs.wiremock.io/response-templating/random-values/
* added transformer field to response type
* add local-response-templating to command options 
![Screenshot 2023-07-10 at 16 45 33](https://github.com/osskit/wiremock-client/assets/130278038/a8ef0f28-f86d-449f-8b48-32482ea5fef6)
* test body with generated random string

